### PR TITLE
Remove coffee-script dep.

### DIFF
--- a/lib/js/coffeescript.js
+++ b/lib/js/coffeescript.js
@@ -1,8 +1,9 @@
 'use strict';
 
 var Bluebird = require('bluebird');
-var coffee = require('coffee-script');
+var resolve = require('resolve');
 
 module.exports = Bluebird.method(function (code) {
+  var coffee = require(resolve.sync('coffee-script', {basedir: process.cwd()}));
   return coffee.compile(code);
 });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "bluebird": "^2.9.34",
     "browser-sync": "^2.8.2",
     "chalk": "^1.1.1",
-    "coffee-script": "^1.9.3",
     "commander": "^2.8.1",
     "ejs": "^2.3.3",
     "es6-promise": "^3.0.2",
@@ -44,6 +43,7 @@
     "node-sass": "3.2.x",
     "normalize.css": "^3.0.3",
     "postcss": "^5.0.4",
+    "resolve": "^1.1.6",
     "stylus": "^0.52.0",
     "swig": "^1.4.2",
     "typescript": "^1.5.3"


### PR DESCRIPTION
Here is an example of how you can avoid installing all of these dependencies up front.

Now if you want `coffee-script` support, you just have to `npm install coffee-script` in your project folder after `wpg`. This has the added advantage of being able to pick the version of coffee-script that you want to use for each project vs whatever is bundled with wpg.

This should make wpg easier to install and to maintain. What do you think?